### PR TITLE
AOS-512: rename consumerOrgno to consumer in mpauth

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -56,7 +56,7 @@
   <component name="PDMPlugin">
     <option name="skipTestSources" value="false" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_20" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/log-event/src/main/avro/mp-authentication.avsc
+++ b/log-event/src/main/avro/mp-authentication.avsc
@@ -123,13 +123,13 @@
       "doc": "Formerly known as clientAmr"
     },
     {
-      "name": "consumer_orgno",
+      "name": "consumer",
       "type": [
         "null",
         "string"
       ],
       "default": null,
-      "doc": "Organization number of the consumer"
+      "doc": "Consumer"
     },    {
       "name": "extra_data",
       "type": [

--- a/log-event/src/main/java/no/digdir/logging/event/MPAuthenticationRecord.java
+++ b/log-event/src/main/java/no/digdir/logging/event/MPAuthenticationRecord.java
@@ -20,7 +20,7 @@ public class MPAuthenticationRecord extends EventRecordBase {
     private final String kid;
     private final String aud;
     private final String tokenEndpointAuthMethod;
-    private final String consumerOrgno;
+    private final String consumer;
 
     @Builder
     public MPAuthenticationRecord(
@@ -36,7 +36,7 @@ public class MPAuthenticationRecord extends EventRecordBase {
             String kid,
             String aud,
             String tokenEndpointAuthMethod,
-            String consumerOrgno,
+            String consumer,
             Instant eventCreated) {
         super(eventName, eventDescription, correlationId, extraData, eventCreated);
         this.clientId = clientId;
@@ -47,7 +47,7 @@ public class MPAuthenticationRecord extends EventRecordBase {
         this.kid = kid;
         this.aud = aud;
         this.tokenEndpointAuthMethod = tokenEndpointAuthMethod;
-        this.consumerOrgno = consumerOrgno;
+        this.consumer = consumer;
     }
 
     @Override
@@ -70,7 +70,7 @@ public class MPAuthenticationRecord extends EventRecordBase {
                 .setKid(kid)
                 .setAud(aud)
                 .setTokenEndpointAuthMethod(tokenEndpointAuthMethod)
-                .setConsumerOrgno(consumerOrgno)
+                .setConsumer(consumer)
                 .build();
     }
 }

--- a/log-event/src/test/java/no/digdir/logging/event/MPAuthenticationRecordTest.java
+++ b/log-event/src/test/java/no/digdir/logging/event/MPAuthenticationRecordTest.java
@@ -31,7 +31,7 @@ class MPAuthenticationRecordTest {
                 .kid("kid")
                 .aud("aud")
                 .tokenEndpointAuthMethod("TokenEndpointAuthMethod")
-                .consumerOrgno("consumerOrgno")
+                .consumer("consumer")
                 .build();
 
         EventLoggingConfig config = EventLoggingConfig.builder()
@@ -65,7 +65,7 @@ class MPAuthenticationRecordTest {
                 .kid("kid")
                 .aud("aud")
                 .tokenEndpointAuthMethod("TokenEndpointAuthMethod")
-                .consumerOrgno("consumerOrgno")
+                .consumer("consumer")
                 .build();
 
         EventLoggingConfig config = EventLoggingConfig.builder()
@@ -89,7 +89,7 @@ class MPAuthenticationRecordTest {
         assertEquals(record.getKid(), avroRecord.getKid());
         assertEquals(record.getAud(), avroRecord.getAud());
         assertEquals(record.getTokenEndpointAuthMethod(), avroRecord.getTokenEndpointAuthMethod());
-        assertEquals(record.getConsumerOrgno(), avroRecord.getConsumerOrgno());
+        assertEquals(record.getConsumer(), avroRecord.getConsumer());
         assertEquals(record.getCorrelationId(), avroRecord.getCorrelationId());
         assertEquals(record.getExtraData(), avroRecord.getExtraData());
         assertEquals(record.getEventCreated().toEpochMilli(), avroRecord.getEventCreated().toEpochMilli());


### PR DESCRIPTION
Et 3-amigos møte hadde konkludert med at feltet måtte hete `consumer`